### PR TITLE
Add auto-linting in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,12 @@
+---
+
+name: Lint
+
+"on":
+  pull_request:
+    branches:
+      - main
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -9,4 +18,4 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npm install
-      - run: npm lint
+      - run: npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,12 @@
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Lint code using Standard 
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - run: npm lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,5 +17,5 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install
+      - run: npm ci
       - run: npm run lint

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ healthcheckHttp.listen(config.event_queue.healthcheck_port)
     eth: new Nanoeth(config.ethereum.http_endpoint),
     startHeight,
     confirmations: config.ethereum.confirmations,
-    stakingAddresses: config.ethereum.staking.addresses.map(function(address) {return address.toLowerCase()}),
+    stakingAddresses: config.ethereum.staking.addresses.map(function (address) { return address.toLowerCase() }),
     stakingStartHeight: config.ethereum.staking.start_height,
     erc20BridgeAddress: config.ethereum.erc20_bridge.address.toLowerCase(),
     erc20BridgeStartHeight: config.ethereum.erc20_bridge.start_height,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "lint": "standard",
+    "lint:fix": "standard --fix"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`standard` is already a dev dependency. Add it as an action.

- Add `lint` npm script (it runs `standard`)
- Add `lint:fix' npm script (it runs `standard --fix`)
- Add github action to run `lint`
- Fix one linting error

Minor change. But hey, linting.
